### PR TITLE
Add viewCount

### DIFF
--- a/src/posts/post.service.ts
+++ b/src/posts/post.service.ts
@@ -81,11 +81,19 @@ export class PostService {
     return { posts, totalCount };
   }
 
-  findOne(id: number) {
-    return this.postRepository.findOne({
+  async findOne(id: number) {
+    const post = await this.postRepository.findOne({
       where: { id },
       relations: ['category'],
     });
+
+    if (post) {
+      // viewCount 증가
+      await this.postRepository.increment({ id }, 'viewCount', 1);
+      post.viewCount += 1; // 반환되는 객체에도 증가된 값 반영
+    }
+
+    return post;
   }
 
   update(id: number, updatePostDto: UpdatePostDto) {


### PR DESCRIPTION
## Summary by Sourcery

Add view count tracking by incrementing a post's viewCount each time it is retrieved via findOne

New Features:
- Increment post.viewCount in the database and returned object on each findOne call

Enhancements:
- Convert findOne method to async to support updating viewCount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Post view counts now automatically increase each time a post is viewed.

- **Bug Fixes**
  - Ensured that the displayed view count accurately reflects the most recent value after a post is viewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->